### PR TITLE
Undefined method getEmitter() -> getEventEmitter()

### DIFF
--- a/src/TestRunner/LocalTestRunner.php
+++ b/src/TestRunner/LocalTestRunner.php
@@ -33,7 +33,7 @@ class LocalTestRunner
     {
         $this->registerHandlers();
 
-        $emitter = $this->getEmitter();
+        $emitter = $this->getEventEmitter();
 
         $emitter->emit('phantestic.tests.before', [$this]);
 


### PR DESCRIPTION
Discovered a call to $this->getEmitter() which is not defined. Assuming getEventEmitter()
